### PR TITLE
[no ticket] change cert authority for ssl requests

### DIFF
--- a/lib/paypal-sdk/core/util/http_helper.rb
+++ b/lib/paypal-sdk/core/util/http_helper.rb
@@ -34,7 +34,8 @@ module PayPal::SDK::Core
 
       # Default ca file
       def default_ca_file
-        File.expand_path("../../../../../data/paypal.crt", __FILE__)
+        #File.expand_path("../../../../../data/paypal.crt", __FILE__)
+        '/etc/ssl/certs/ca-certificates.crt'
       end
 
       # Apply ssl configuration to http object


### PR DESCRIPTION
- use default debian cert authority instead of the stale one provided by the sdk